### PR TITLE
👷 Makefile: deploy to PyPi fix 🕷

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ quality:
 	pylint src/susan
 
 deploy: install-dependencies clean build
-	twine upload dist/
+	twine upload dist/*
 


### PR DESCRIPTION
Fixed the `Makefile` to use `twine upload dist/*` instead of `twine upload dist/`, which didn't detect the folders.